### PR TITLE
Allow pid-rs to be used in embedded systems (no_std).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ repository = "https://github.com/braincore/pid-rs"
 keywords = ["pid"]
 readme = "README.md"
 
-[dependencies]
-num-traits = "0.2"
+[dependencies.num-traits]
+version = "0.2"
+default-features = false
 
 [badges]
 travis-ci = { repository = "braincore/pid-rs" }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A proportional-integral-derivative (PID) controller.
   * Mitigation of output jumps when changing `ki` by storing the integration of
     `e(t) * ki(t)` rather than only `e(t)`.
 * Generic float type parameter to support `f32` or `f64`.
+* Support for `no_std` environments, such as embedded systems.
 
 ## Assumptions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! A proportional-integral-derivative (PID) controller.
-
+#![no_std]
 extern crate num_traits;
-use num_traits::Float;
+use num_traits::float::FloatCore;
 
 #[derive(Debug)]
-pub struct Pid<T: Float> {
+pub struct Pid<T: FloatCore> {
     /// Proportional gain.
     pub kp: T,
     /// Integral gain.
@@ -25,7 +25,7 @@ pub struct Pid<T: Float> {
 }
 
 #[derive(Debug)]
-pub struct ControlOutput<T: Float> {
+pub struct ControlOutput<T: FloatCore> {
     /// Contribution of the P term to the output.
     pub p: T,
     /// Contribution of the I term to the output.
@@ -39,7 +39,7 @@ pub struct ControlOutput<T: Float> {
 
 impl<T> Pid<T>
 where
-    T: Float,
+    T: FloatCore,
 {
     pub fn new(kp: T, ki: T, kd: T, p_limit: T, i_limit: T, d_limit: T) -> Self {
         Self {


### PR DESCRIPTION
This patch allows pid-rs to work with embedded systems by removing unnecessary dependencies on std.