### PR TITLE
add global limit; remove all limits from constructor args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,14 +41,15 @@ impl<T> Pid<T>
 where
     T: FloatCore,
 {
-    pub fn new(kp: T, ki: T, kd: T, p_limit: T, i_limit: T, d_limit: T, setpoint: T) -> Self {
+    pub fn new(kp: T, ki: T, kd: T, setpoint: T) -> Self {
+        let inf = T::infinity();
         Self {
             kp,
             ki,
             kd,
-            p_limit,
-            i_limit,
-            d_limit,
+            p_limit : inf,
+            i_limit : inf,
+            d_limit : inf,
             setpoint,
             prev_measurement: None,
             integral_term: T::zero(),
@@ -62,9 +63,6 @@ where
     }
 
     /// Given a new measurement, calculates the next control output.
-    ///
-    /// # Panics
-    /// If a setpoint has not been set via `update_setpoint()`.
     pub fn next_control_output(&mut self, measurement: T) -> ControlOutput<T> {
         let error = self.setpoint - measurement;
 
@@ -106,7 +104,7 @@ mod tests {
 
     #[test]
     fn proportional() {
-        let mut pid = Pid::new(2.0, 0.0, 0.0, 100.0, 100.0, 100.0, 10.0);
+        let mut pid = Pid::new(2.0, 0.0, 0.0, 10.0);
         assert_eq!(pid.setpoint, 10.0);
 
         // Test simple proportional
@@ -119,7 +117,7 @@ mod tests {
 
     #[test]
     fn derivative() {
-        let mut pid = Pid::new(0.0, 0.0, 2.0, 100.0, 100.0, 100.0, 10.0);
+        let mut pid = Pid::new(0.0, 0.0, 2.0, 10.0);
 
         // Test that there's no derivative since it's the first measurement
         assert_eq!(pid.next_control_output(0.0).output, 0.0);
@@ -134,7 +132,7 @@ mod tests {
 
     #[test]
     fn integral() {
-        let mut pid = Pid::new(0.0, 2.0, 0.0, 100.0, 100.0, 100.0, 10.0);
+        let mut pid = Pid::new(0.0, 2.0, 0.0, 10.0);
 
         // Test basic integration
         assert_eq!(pid.next_control_output(0.0).output, 20.0);
@@ -148,7 +146,7 @@ mod tests {
         assert_eq!(pid.next_control_output(15.0).output, 40.0);
 
         // Test that error integral accumulates negative values
-        let mut pid2 = Pid::new(0.0, 2.0, 0.0, 100.0, 100.0, 100.0, -10.0);
+        let mut pid2 = Pid::new(0.0, 2.0, 0.0, -10.0);
         assert_eq!(pid2.next_control_output(0.0).output, -20.0);
         assert_eq!(pid2.next_control_output(0.0).output, -40.0);
 
@@ -160,7 +158,7 @@ mod tests {
 
     #[test]
     fn pid() {
-        let mut pid = Pid::new(1.0, 0.1, 1.0, 100.0, 100.0, 100.0, 10.0);
+        let mut pid = Pid::new(1.0, 0.1, 1.0, 10.0);
 
         let out = pid.next_control_output(0.0);
         assert_eq!(out.p, 10.0); // 1.0 * 10.0
@@ -189,9 +187,9 @@ mod tests {
 
     #[test]
     fn f32_and_f64() {
-        let mut pid32 = Pid::new(2.0f32, 0.0, 0.0, 100.0, 100.0, 100.0, 10.0);
+        let mut pid32 = Pid::new(2.0f32, 0.0, 0.0, 10.0);
 
-        let mut pid64 = Pid::new(2.0f64, 0.0, 0.0, 100.0, 100.0, 100.0, 10.0);
+        let mut pid64 = Pid::new(2.0f64, 0.0, 0.0, 10.0);
 
         assert_eq!(
             pid32.next_control_output(0.0).output,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub struct Pid<T: FloatCore> {
     pub i_limit: T,
     /// Limit of contribution of D term `(-d_limit <= D <= d_limit)`
     pub d_limit: T,
+    /// Limit of the sum of PID terms `(-limit <= P + I + D <+ limit)`
+    pub limit : T,
 
     pub setpoint: T,
     prev_measurement: Option<T>,
@@ -50,6 +52,7 @@ where
             p_limit : inf,
             i_limit : inf,
             d_limit : inf,
+            limit : inf,
             setpoint,
             prev_measurement: None,
             integral_term: T::zero(),
@@ -89,11 +92,14 @@ where
         self.prev_measurement = Some(measurement);
         let d = self.d_limit.min(d_unbounded.abs()) * d_unbounded.signum();
 
+        let output_unbounded = p + self.integral_term + d;
+        let output = self.limit.min(output_unbounded.abs()) * output_unbounded.signum();
+
         ControlOutput {
             p,
             i: self.integral_term,
             d,
-            output: (p + self.integral_term + d),
+            output: output
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub struct Pid<T: FloatCore> {
     /// Limit of contribution of D term `(-d_limit <= D <= d_limit)`
     pub d_limit: T,
     /// Limit of the sum of PID terms `(-limit <= P + I + D <+ limit)`
-    pub limit : T,
+    pub limit: T,
 
     pub setpoint: T,
     prev_measurement: Option<T>,
@@ -49,10 +49,10 @@ where
             kp,
             ki,
             kd,
-            p_limit : inf,
-            i_limit : inf,
-            d_limit : inf,
-            limit : inf,
+            p_limit: inf,
+            i_limit: inf,
+            d_limit: inf,
+            limit: inf,
             setpoint,
             prev_measurement: None,
             integral_term: T::zero(),
@@ -99,7 +99,7 @@ where
             p,
             i: self.integral_term,
             d,
-            output: output
+            output: output,
         }
     }
 }
@@ -206,5 +206,4 @@ mod tests {
             pid64.next_control_output(0.0).output
         );
     }
-
 }


### PR DESCRIPTION
I added global limit.

All limits are not `new()` args anymore, since many users might not need limits. They are defaulted to be `T:infinity()`.