### PR TITLE
change PID formula from gif to markdown math block

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ assert_eq!(output.d, -10.0);
 There are several different formulations of PID controllers. This library
 uses the independent form:
 
-![PID independent form](
-https://latex.codecogs.com/gif.latex?C(t)&space;=&space;&space;K_p&space;\cdot&space;e(t)&space;&plus;&space;K_i&space;\cdot&space;\int{e(t)dt}&space;-&space;K_d&space;\cdot&space;\frac{dP(t)}{dt})
+```math
+C(t) = K_p \cdot e(t) + K_i \cdot \int{e(t)dt} - K_d \cdot \frac{dP(t)}{dt}
+```
 
 where:
 - C(t) = control output, the output to the actuator.


### PR DESCRIPTION
Hi :) i turned the PID formula from embedded codecogs gif into a markdown math block. It seems to help with both render quality and visibility in a dark theme.

Light theme:
![image](https://user-images.githubusercontent.com/38983836/218333459-5bee40d8-a78a-48f3-a245-df4411db2d4a.png)

Dark theme:
![image](https://user-images.githubusercontent.com/38983836/218333419-bba4759d-5a2b-4a55-8f09-40f7490af153.png)
