### PR TITLE
Add categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,15 @@
 name = "pid"
 version = "4.0.0"
 edition = "2018"
-authors = ["Ken Elkabany <ken@elkabany.com>", "Owez Griffiths <root@ogriffiths.com>"]
+authors = [
+    "Ken Elkabany <ken@elkabany.com>",
+    "Owez Griffiths <root@ogriffiths.com>",
+]
 license = "MIT OR Apache-2.0"
 description = "A PID controller."
 repository = "https://github.com/braincore/pid-rs"
 keywords = ["pid"]
+categories = ["no-std", "embedded", "algorithms"]
 readme = "README.md"
 
 [dependencies.num-traits]
@@ -21,4 +25,3 @@ features = ["derive"]
 
 [badges]
 travis-ci = { repository = "braincore/pid-rs" }
-


### PR DESCRIPTION
Adds `["no-std", "embedded", "algorithms"]` as categories to the Cargo.toml and some TOML formatting.

Closes #16 