### PR TITLE
Added Functionality to manually set the integral term.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,13 @@ where
     pub fn reset_integral_term(&mut self) {
         self.integral_term = T::zero();
     }
+
+    /// Set integral term to custom value. This might be important to set pid
+    /// controller to previous state after an interruption or crash
+    pub fn set_integral_term(&mut self, integral_term: impl Into<T>) -> &mut Self {
+        self.integral_term = integral_term.into();
+        self
+    }
 }
 
 /// Saturating the input `value` according the absolute `limit` (`-abs(limit) <= output <= abs(limit)`).


### PR DESCRIPTION
This might be important to set controller to previous state after an interruption or crash. It also allows for more manual manipulation of the PID controller if that is desired.
I have added a function set_integral_term() which is very similar to reset_integral_term() but takes the desired value as a parameter. 
I have left the original reset_integral_term() in the code even though this kinda doubles functionality to not break behaviour that might be expected by people that have used the reset_integral_term() before.