### PR TITLE
Add features: A combination of other PRs + Making the API more flexible.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["no-std", "embedded", "algorithms"]
 readme = "README.md"
 
 [dependencies]
+num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,8 @@ keywords = ["pid"]
 categories = ["no-std", "embedded", "algorithms"]
 readme = "README.md"
 
-[dependencies.num-traits]
-version = "0.2"
-default-features = false
-
-[dependencies.serde]
-version = "1.0"
-optional = true
-default-features = false
-features = ["derive"]
+[dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [badges]
 travis-ci = { repository = "braincore/pid-rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ where
         // Call normal update
         self.update(input)
             .map(|out| self.ki.map_or(
-                Some(out),
+                out,
                 |ki| {
                     // Convert parameters to number type
                     let dt: T = dt.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,34 @@ where
     }
 }
 
+impl<T: Number + !i8 + !i16 + !i32 + !i64 + !i128 + !f32 + !f64> Pid<T>
+{
+    /// Creates a new controller
+    ///
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub fn new() -> Self {
+        Self {
+            setpoint: T::default(),
+            kp: T::default(),
+            ki: T::default(),
+            kd: T::default(),
+            p_limit_high: T::default(),
+            p_limit_low: T::default(),
+            i_limit_high: T::default(),
+            i_limit_low: T::default(),
+            d_limit_high: T::default(),
+            d_limit_low: T::default(),
+            o_limit_high: T::default(),
+            o_limit_low: T::default(),
+            i_term: T::default(),
+            prev_measurement: None,
+        }
+    }
+}
+
 impl Pid<i8>
 {
     pub const fn new() -> Self {
@@ -371,31 +399,6 @@ impl Pid<f64>
 
 impl<T: Number> Pid<T>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
-    pub fn new() -> Self {
-        Self {
-            setpoint: T::default(),
-            kp: T::default(),
-            ki: T::default(),
-            kd: T::default(),
-            p_limit_high: T::default(),
-            p_limit_low: T::default(),
-            i_limit_high: T::default(),
-            i_limit_low: T::default(),
-            d_limit_high: T::default(),
-            d_limit_low: T::default(),
-            o_limit_high: T::default(),
-            o_limit_low: T::default(),
-            i_term: T::default(),
-            prev_measurement: None,
-        }
-    }
-
     /// Sets the [Self::p] gain for this controller.
     pub fn p(&mut self, gain: impl Into<T>) -> &mut Self {
         self.kp = gain.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,22 +254,22 @@ where
     } 
 
     /// Sets the min limits for this controller.
-    pub fn clamp_max(&mut self, max: impl Into<T>) -> &mut Self {
-        let max: T = max.into();
-        self.p_limit.max = Some(max);
-        self.i_limit.max = Some(max);
-        self.d_limit.max = Some(max);
-        self.out_limit.max = Some(max);
-        self
-    }
-
-    /// Sets the max limits for this controller.
     pub fn clamp_min(&mut self, min: impl Into<T>) -> &mut Self {
         let min: T = min.into();
         self.p_limit.min = Some(min);
         self.i_limit.min = Some(min);
         self.d_limit.min = Some(min);
         self.out_limit.min = Some(min);
+        self
+    }
+
+    /// Sets the max limits for this controller.
+    pub fn clamp_max(&mut self, max: impl Into<T>) -> &mut Self {
+        let max: T = max.into();
+        self.p_limit.max = Some(max);
+        self.i_limit.max = Some(max);
+        self.d_limit.max = Some(max);
+        self.out_limit.max = Some(max);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ where
 /// # Type Warning
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Send)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T: Number> {
     /// Ideal setpoint to strive for.
@@ -176,7 +176,7 @@ pub struct Pid<T: Number> {
 /// let output = pid.next_control_output(26.2456);
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Send)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ControlOutput<T: Number> {
     /// Contribution of the P term to the output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,161 @@ where
     }
 }
 
-impl<T: Number + !i8 + !i16 + !i32 + !i64 + !i128 + !f32 + !f64> Pid<T>
+impl Pid<i8>
+{
+    pub const fn new_const() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<i16>
+{
+    pub const fn new_const() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<i32>
+{
+    pub const fn new_const() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<i64>
+{
+    pub const fn new_const() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<i128>
+{
+    pub const fn new_const() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<f32>
+{
+    pub const fn new_const() -> Self {
+        Self {
+            setpoint: 0.0,
+            kp: 0.0,
+            ki: 0.0,
+            kd: 0.0,
+            p_limit_high: 0.0,
+            p_limit_low: 0.0,
+            i_limit_high: 0.0,
+            i_limit_low: 0.0,
+            d_limit_high: 0.0,
+            d_limit_low: 0.0,
+            o_limit_high: 0.0,
+            o_limit_low: 0.0,
+            i_term: 0.0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<f64>
+{
+    pub const fn new_const() -> Self {
+        Self {
+            setpoint: 0.0,
+            kp: 0.0,
+            ki: 0.0,
+            kd: 0.0,
+            p_limit_high: 0.0,
+            p_limit_low: 0.0,
+            i_limit_high: 0.0,
+            i_limit_low: 0.0,
+            d_limit_high: 0.0,
+            d_limit_low: 0.0,
+            o_limit_high: 0.0,
+            o_limit_low: 0.0,
+            i_term: 0.0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl<T: Number> Pid<T>
 {
     /// Creates a new controller
     ///
@@ -241,164 +395,7 @@ impl<T: Number + !i8 + !i16 + !i32 + !i64 + !i128 + !f32 + !f64> Pid<T>
             prev_measurement: None,
         }
     }
-}
 
-impl Pid<i8>
-{
-    pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<i16>
-{
-    pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<i32>
-{
-    pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<i64>
-{
-    pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<i128>
-{
-    pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<f32>
-{
-    pub const fn new() -> Self {
-        Self {
-            setpoint: 0.0,
-            kp: 0.0,
-            ki: 0.0,
-            kd: 0.0,
-            p_limit_high: 0.0,
-            p_limit_low: 0.0,
-            i_limit_high: 0.0,
-            i_limit_low: 0.0,
-            d_limit_high: 0.0,
-            d_limit_low: 0.0,
-            o_limit_high: 0.0,
-            o_limit_low: 0.0,
-            i_term: 0.0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<f64>
-{
-    pub const fn new() -> Self {
-        Self {
-            setpoint: 0.0,
-            kp: 0.0,
-            ki: 0.0,
-            kd: 0.0,
-            p_limit_high: 0.0,
-            p_limit_low: 0.0,
-            i_limit_high: 0.0,
-            i_limit_low: 0.0,
-            d_limit_high: 0.0,
-            d_limit_low: 0.0,
-            o_limit_high: 0.0,
-            o_limit_low: 0.0,
-            i_term: 0.0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl<T: Number> Pid<T>
-{
     /// Sets the [Self::p] gain for this controller.
     pub fn p(&mut self, gain: impl Into<T>) -> &mut Self {
         self.kp = gain.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,14 +63,20 @@ use num_traits::CheckedMul;
 ///
 /// As well as any user type that matches the requirements
 pub trait Number: num_traits::sign::Signed
-    + num_traits::ops::checked::CheckedAdd
+    + PartialOrd
+    + Copy
+{}
+
+pub trait CheckedBasic: num_traits::ops::checked::CheckedAdd
     + num_traits::ops::checked::CheckedSub
     + num_traits::ops::checked::CheckedMul
     + num_traits::ops::checked::CheckedDiv
     + num_traits::ops::checked::CheckedNeg
-    + PartialOrd
-    + Copy
-    + Send
+{}
+
+impl<T> CheckedBasic for T
+where
+    T: Number
 {}
 
 /// An error emitted due to problems with the PID controller.
@@ -216,7 +222,7 @@ where
 
 impl<T> Pid<T>
 where
-    T: Number
+    T: Number + CheckedBasic
 {
     /// Creates a new controller
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,6 @@
 //! ```
 #![no_std]
 
-use core::num;
-
-use num_traits::CheckedMul;
-
 /// A trait for any numeric type usable in the PID controller
 ///
 /// This trait is automatically implemented for all types that satisfy `PartialOrd + num_traits::Signed + Copy`. This includes all of the signed float types and builtin integer except for [isize]:
@@ -117,7 +113,7 @@ pub enum PidError {
 /// # Type Warning
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T: Number> {
     /// Ideal setpoint to strive for.
@@ -178,7 +174,7 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PidLimit<T: Number> {
     min: Option<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-impl<T: Number + num_traits::int::PrimInt> Pid<T>
+impl Pid<i8>
 {
     /// Creates a new controller
     ///
@@ -199,7 +199,7 @@ impl<T: Number + num_traits::int::PrimInt> Pid<T>
     /// - [Self::p()]: Proportional gain setting
     /// - [Self::i()]: Integral gain setting
     /// - [Self::d()]: Derivative gain setting
-    pub const fn new_int() -> Self {
+    pub const fn new() -> Self {
         Self {
             setpoint: 0,
             kp: 0,
@@ -219,7 +219,7 @@ impl<T: Number + num_traits::int::PrimInt> Pid<T>
     }
 }
 
-impl<T: Number + num_traits::float::FloatCore> Pid<T>
+impl Pid<i16>
 {
     /// Creates a new controller
     ///
@@ -227,7 +227,147 @@ impl<T: Number + num_traits::float::FloatCore> Pid<T>
     /// - [Self::p()]: Proportional gain setting
     /// - [Self::i()]: Integral gain setting
     /// - [Self::d()]: Derivative gain setting
-    pub const fn new_float() -> Self {
+    pub const fn new() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<i32>
+{
+    /// Creates a new controller
+    ///
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub const fn new() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<i64>
+{
+    /// Creates a new controller
+    ///
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub const fn new() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<i128>
+{
+    /// Creates a new controller
+    ///
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub const fn new() -> Self {
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<f32>
+{
+    /// Creates a new controller
+    ///
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub const fn new() -> Self {
+        Self {
+            setpoint: 0.0,
+            kp: 0.0,
+            ki: 0.0,
+            kd: 0.0,
+            p_limit_high: 0.0,
+            p_limit_low: 0.0,
+            i_limit_high: 0.0,
+            i_limit_low: 0.0,
+            d_limit_high: 0.0,
+            d_limit_low: 0.0,
+            o_limit_high: 0.0,
+            o_limit_low: 0.0,
+            i_term: 0.0,
+            prev_measurement: None,
+        }
+    }
+}
+
+impl Pid<f64>
+{
+    /// Creates a new controller
+    ///
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub const fn new() -> Self {
         Self {
             setpoint: 0.0,
             kp: 0.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! assert_eq!(output.p, 50.0);
 //!
 //! // It won't change on repeat; the controller is proportional-only
-//! let output = pid.next_control_output(10.0).unwrap();
+//! let output = pid.update(10.0).unwrap();
 //! assert_eq!(output.output, 50.0); // <--
 //! assert_eq!(output.p, 50.0);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,11 @@
 /// - [f64]
 ///
 /// As well as any user type that matches the requirements
-pub trait Number: num_traits::sign::Signed
-    + PartialOrd
-    + Copy
-{}
+pub trait Number: PartialOrd + num_traits::Signed + Copy {}
+
+// Implement `Number` for all types that
+// satisfy `PartialOrd + num_traits::Signed + Copy`.
+impl<T: PartialOrd + num_traits::Signed + Copy> Number for T {}
 
 /// An error emitted due to problems with the PID controller.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,10 +191,7 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-impl<T> Pid<T>
-where
-    T: Number +
-        num_traits::int::PrimInt,
+impl<T: Number + num_traits::int::PrimInt> Pid<T>
 {
     /// Creates a new controller
     ///
@@ -202,7 +199,7 @@ where
     /// - [Self::p()]: Proportional gain setting
     /// - [Self::i()]: Integral gain setting
     /// - [Self::d()]: Derivative gain setting
-    pub const fn new() -> Self {
+    pub const fn new_int() -> Self {
         Self {
             setpoint: 0,
             kp: 0,
@@ -222,10 +219,7 @@ where
     }
 }
 
-impl<T> Pid<T>
-where
-    T: Number
-        + num_traits::float::FloatCore,
+impl<T: Number + num_traits::float::FloatCore> Pid<T>
 {
     /// Creates a new controller
     ///
@@ -233,7 +227,7 @@ where
     /// - [Self::p()]: Proportional gain setting
     /// - [Self::i()]: Integral gain setting
     /// - [Self::d()]: Derivative gain setting
-    pub const fn new() -> Self {
+    pub const fn new_float() -> Self {
         Self {
             setpoint: 0.0,
             kp: 0.0,
@@ -253,9 +247,7 @@ where
     }
 }
 
-impl<T> Pid<T>
-where
-    T: Number,
+impl<T: Number> Pid<T>
 {
     /// Sets the [Self::p] gain for this controller.
     pub fn p(&mut self, gain: impl Into<T>) -> &mut Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,14 @@ pub struct Pid<T> {
     pub out_limit: PidLimit<T>, 
 }
 
+/// Limits of controller terms
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct PidLimit<T> {
+    min: Option<T>,
+    max: Option<T>,
+}
+
 /// Output of [controller iterations](Pid::next_control_output) with weights
 ///
 /// # Example
@@ -170,13 +178,7 @@ pub struct ControlOutput<T> {
     pub output: T,
 }
 
-#[derive(Clone, Copy, Eq, PartialEqa)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct PidLimit<T> {
-    min: Option<T>,
-    max: Option<T>,
-}
-
+// PidLimit methods
 impl<T> PidLimit<T>
 where
     T: Number
@@ -209,6 +211,7 @@ where
     }
 }
 
+// Pid methods
 impl<T> Pid<T>
 where
     T: Number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,20 +14,20 @@
 //!     .p(10.0);
 //!
 //! // Input a measurement with an error of 5.0 from our setpoint
-//! let output = pid.next_control_output(10.0);
+//! let output = pid.next_control_output(10.0).unwrap();
 //!
 //! // Show that the error is correct by multiplying by our kp
 //! assert_eq!(output.output, 50.0); // <--
 //! assert_eq!(output.p, 50.0);
 //!
 //! // It won't change on repeat; the controller is proportional-only
-//! let output = pid.next_control_output(10.0);
+//! let output = pid.next_control_output(10.0).unwrap();
 //! assert_eq!(output.output, 50.0); // <--
 //! assert_eq!(output.p, 50.0);
 //!
 //! // Add a new integral term to the controller and input again
 //! pid.i(1.0);
-//! let output = pid.next_control_output(10.0);
+//! let output = pid.next_control_output(10.0).unwrap();
 //!
 //! // Now that the integral makes the controller stateful, it will change
 //! assert_eq!(output.output, 55.0); // <--
@@ -36,7 +36,7 @@
 //!
 //! // Add our final derivative term and match our setpoint target
 //! pid.d(2.0);
-//! let output = pid.next_control_output(15.0);
+//! let output = pid.next_control_output(15.0).unwrap();
 //!
 //! // The output will now say to go down due to the derivative
 //! assert_eq!(output.output, -5.0); // <--
@@ -45,6 +45,10 @@
 //! assert_eq!(output.d, -10.0);
 //! ```
 #![no_std]
+
+use core::num;
+
+use num_traits::CheckedMul;
 
 /// A trait for any numeric type usable in the PID controller
 ///
@@ -58,25 +62,22 @@
 /// - [f64]
 ///
 /// As well as any user type that matches the requirements
-pub trait Number: num_traits::sign::Signed + PartialOrd + Default + Copy + Send {
-    fn clamp(self, min: Self, max: Self) -> Self;
-}
+pub trait Number: num_traits::sign::Signed
+    + num_traits::ops::checked::CheckedAdd
+    + num_traits::ops::checked::CheckedSub
+    + num_traits::ops::checked::CheckedMul
+    + num_traits::ops::checked::CheckedDiv
+    + num_traits::ops::checked::CheckedNeg
+    + PartialOrd
+    + Copy
+    + Send
+{}
 
-// Implement `Number` for all types that
-// satisfy `PartialOrd + num_traits::Signed + Copy`.
-impl<T> Number for T
-where
-    T: num_traits::sign::Signed
-        + PartialOrd
-        + Default
-        + Copy
-        + Send,
-{
-    fn clamp(self, min: Self, max: Self) -> Self {
-        if self < min {min} else 
-        if self > max {max} else 
-        {self}
-    }
+/// An error emitted due to problems with the PID controller.
+#[derive(Debug)]
+pub enum PidError {
+    NoSetpoint,
+    OpOverflow,
 }
 
 /// Adjustable proportional-integral-derivative (PID) controller.
@@ -95,7 +96,7 @@ where
 ///     .p(10.0);
 ///
 /// // Get first output
-/// let p_output = p_controller.next_control_output(400.0);
+/// let p_output = p_controller.next_control_output(400.0).unwrap();
 /// ```
 ///
 /// This controller would give you set a proportional controller to `10.0` with a target of `15.0` and an output limit of `100.0` per [output](Self::next_control_output) iteration. The same controller with a full PID system built in looks like:
@@ -112,7 +113,7 @@ where
 ///     .d(0.25);
 ///
 /// // Get first output
-/// let full_output = full_controller.next_control_output(400.0);
+/// let full_output = full_controller.next_control_output(400.0).unwrap();
 /// ```
 ///
 /// This [`next_control_output`](Self::next_control_output) method is what's used to input new values into the controller to tell it what the current state of the system is. In the examples above it's only being used once, but realistically this will be a hot method. Please see [ControlOutput] for examples of how to handle these outputs; it's quite straight forward and mirrors the values of this structure in some ways.
@@ -126,33 +127,25 @@ where
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T: Number> {
     /// Ideal setpoint to strive for.
-    pub setpoint: T,
+    pub setpoint: Option<T>,
     /// Proportional gain.
-    pub kp: T,
+    pub kp: Option<T>,
     /// Integral gain.
-    pub ki: T,
+    pub ki: Option<T>,
     /// Derivative gain.
-    pub kd: T,
-    /// Limiter for the proportional term: `-p_limit <= P <= p_limit`.
-    pub p_limit_high: T,
-    /// Limiter for the derivative term: `p_limit_low <= P <= p_limit`.
-    pub p_limit_low: T,
-    /// Limiter for the integral term: `i_limit_low <= I <= i_limit_high`.
-    pub i_limit_high: T,
-    /// Limiter for the derivative term: `i_limit_low <= I <= i_limit_high`.
-    pub i_limit_low: T,
-    /// Limiter for the derivative term: `d_limit_low <= D <= d_limit_high`.
-    pub d_limit_high: T,
-    /// Limiter for the derivative term: `d_limit_low <= D <= d_limit_high`.
-    pub d_limit_low: T,
-    /// Limiter for the derivative term: `o_limit_low <= O <= o_limit_high`.
-    pub o_limit_high: T,
-    /// Limiter for the derivative term: `o_limit_low <= O <= o_limit_high`.
-    pub o_limit_low: T,
+    pub kd: Option<T>,
     /// Last calculated integral value if [Pid::ki] is used.
-    pub i_term: T,
+    pub i_term: Option<T>,
     /// Previously found measurement whilst using the [Pid::next_control_output] method.
     pub prev_measurement: Option<T>,
+    /// Limiter for the proportional term: `-p_limit <= P <= p_limit`.
+    pub p_limit: PidLimit<T>,
+    /// Limiter for the integral term: `i_limit_low <= I <= i_limit_high`.
+    pub i_limit: PidLimit<T>,
+    /// Limiter for the derivative term: `d_limit_low <= D <= d_limit_high`.
+    pub d_limit: PidLimit<T>,
+    /// Limiter for the derivative term: `o_limit_low <= O <= o_limit_high`.
+    pub out_limit: PidLimit<T>, 
 }
 
 /// Output of [controller iterations](Pid::next_control_output) with weights
@@ -173,10 +166,10 @@ pub struct Pid<T: Number> {
 ///     .d(2.0);
 ///
 /// // Input an example value and get a report for an output iteration
-/// let output = pid.next_control_output(26.2456);
+/// let output = pid.next_control_output(26.2456).unwrap();
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ControlOutput<T: Number> {
     /// Contribution of the P term to the output.
@@ -191,161 +184,39 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-impl Pid<i8>
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct PidLimit<T: Number> {
+    min: Option<T>,
+    max: Option<T>,
+}
+
+impl<T> PidLimit<T>
+where
+    T: Number
 {
-    pub const fn new_const() -> Self {
+    pub const fn new() -> Self {
         Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
+            min: None,
+            max: None,
         }
+    }
+
+    pub fn clamp(self, value: impl Into<T>) -> T {
+        let mut value: T = value.into();
+        value = if let Some(min) = self.min {
+            if value < min {min} else {value}
+        } else {value};
+        value = if let Some(max) = self.max {
+            if value > max {max} else {value}
+        } else {value};
+        value
     }
 }
 
-impl Pid<i16>
-{
-    pub const fn new_const() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<i32>
-{
-    pub const fn new_const() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<i64>
-{
-    pub const fn new_const() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<i128>
-{
-    pub const fn new_const() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<f32>
-{
-    pub const fn new_const() -> Self {
-        Self {
-            setpoint: 0.0,
-            kp: 0.0,
-            ki: 0.0,
-            kd: 0.0,
-            p_limit_high: 0.0,
-            p_limit_low: 0.0,
-            i_limit_high: 0.0,
-            i_limit_low: 0.0,
-            d_limit_high: 0.0,
-            d_limit_low: 0.0,
-            o_limit_high: 0.0,
-            o_limit_low: 0.0,
-            i_term: 0.0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl Pid<f64>
-{
-    pub const fn new_const() -> Self {
-        Self {
-            setpoint: 0.0,
-            kp: 0.0,
-            ki: 0.0,
-            kd: 0.0,
-            p_limit_high: 0.0,
-            p_limit_low: 0.0,
-            i_limit_high: 0.0,
-            i_limit_low: 0.0,
-            d_limit_high: 0.0,
-            d_limit_low: 0.0,
-            o_limit_high: 0.0,
-            o_limit_low: 0.0,
-            i_term: 0.0,
-            prev_measurement: None,
-        }
-    }
-}
-
-impl<T: Number> Pid<T>
+impl<T> Pid<T>
+where
+    T: Number
 {
     /// Creates a new controller
     ///
@@ -353,61 +224,68 @@ impl<T: Number> Pid<T>
     /// - [Self::p()]: Proportional gain setting
     /// - [Self::i()]: Integral gain setting
     /// - [Self::d()]: Derivative gain setting
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            setpoint: T::default(),
-            kp: T::default(),
-            ki: T::default(),
-            kd: T::default(),
-            p_limit_high: T::default(),
-            p_limit_low: T::default(),
-            i_limit_high: T::default(),
-            i_limit_low: T::default(),
-            d_limit_high: T::default(),
-            d_limit_low: T::default(),
-            o_limit_high: T::default(),
-            o_limit_low: T::default(),
-            i_term: T::default(),
+            setpoint: None,
+            kp: None,
+            ki: None,
+            kd: None,
+            i_term: None,
             prev_measurement: None,
+            p_limit: PidLimit::<T>::new(),
+            i_limit: PidLimit::<T>::new(),
+            d_limit: PidLimit::<T>::new(),
+            out_limit: PidLimit::<T>::new(),
         }
     }
 
     /// Sets the [Self::p] gain for this controller.
     pub fn p(&mut self, gain: impl Into<T>) -> &mut Self {
-        self.kp = gain.into();
+        self.kp = Some(gain.into());
         self
     }
 
     /// Sets the [Self::i] gain for this controller.
     pub fn i(&mut self, gain: impl Into<T>) -> &mut Self {
-        self.ki = gain.into();
+        self.ki = Some(gain.into());
         self
     }
 
     /// Sets the [Self::d] gain for this controller.
     pub fn d(&mut self, gain: impl Into<T>) -> &mut Self {
-        self.kd = gain.into();
+        self.kd = Some(gain.into());
         self
     }
 
     /// Sets the [Pid::setpoint] to target for this controller.
     pub fn setpoint(&mut self, setpoint: impl Into<T>) -> &mut Self {
-        self.setpoint = setpoint.into();
+        self.setpoint = Some(setpoint.into());
         self
     }
 
-    /// Sets the [Self::p] limit for this controller.
-    pub fn clamp(&mut self, low: impl Into<T>, high: impl Into<T>) -> &mut Self {
-        let low: T = low.into();
-        let high: T = high.into();
-        self.p_limit_low = low;
-        self.p_limit_high = high;
-        self.i_limit_low = low;
-        self.i_limit_high = high;
-        self.d_limit_low = low;
-        self.d_limit_high = high;
-        self.o_limit_low = low;
-        self.o_limit_high = high;
+    /// Sets the min and max limits for this controller.
+    pub fn clamp(&mut self, min: impl Into<T>, max: impl Into<T>) -> &mut Self {
+        self.clamp_min(min)
+            .clamp_max(max)
+    } 
+
+    /// Sets the min limits for this controller.
+    pub fn clamp_max(&mut self, max: impl Into<T>) -> &mut Self {
+        let max: T = max.into();
+        self.p_limit.max = Some(max);
+        self.i_limit.max = Some(max);
+        self.d_limit.max = Some(max);
+        self.out_limit.max = Some(max);
+        self
+    }
+
+    /// Sets the max limits for this controller.
+    pub fn clamp_min(&mut self, min: impl Into<T>) -> &mut Self {
+        let min: T = min.into();
+        self.p_limit.min = Some(min);
+        self.i_limit.min = Some(min);
+        self.d_limit.min = Some(min);
+        self.out_limit.min = Some(min);
         self
     }
 
@@ -415,64 +293,89 @@ impl<T: Number> Pid<T>
     /// pid controller to a previous state after an interruption or crash.
     pub fn set_integral_term(&mut self, i_term: impl Into<T>) -> &mut Self {
         let i_unbound: T = i_term.into();
-        self.i_term = i_unbound.clamp(self.i_limit_low, self.i_limit_high);
+        self.i_term = Some(self.i_limit.clamp(i_unbound));
         self
     }
 
     /// Resets the integral term back to zero, this may drastically change the
     /// control output.
     pub fn reset_integral_term(&mut self) -> &mut Self {
-        self.set_integral_term(T::default())
+        self.set_integral_term(T::zero())
     }
 
     /// Given a new measurement, calculates the next [control output](ControlOutput).
     ///
-    /// # Panics
-    ///
-    /// - If a setpoint has not been set via `update_setpoint()`.
-    pub fn next_control_output(&mut self, measurement: impl Into<T>) -> ControlOutput<T> {
+    /// # Returns Error
+    /// 
+    /// - If a setpoint has not been set via `setpoint()`.
+    /// - If an overflow occured in one of the calculations.
+    pub fn next_control_output(&mut self, measurement: impl Into<T>) -> Result<ControlOutput<T>, PidError> {
         let measurement: T = measurement.into();
         
         // Calculate the error between the ideal setpoint and the current
         // measurement to compare against
-        let error = self.setpoint - measurement;
+        let setpoint = self.setpoint.ok_or(PidError::NoSetpoint)?;
+        let error = setpoint.checked_sub(&measurement)
+            .ok_or(PidError::OpOverflow)?;
+        
+        let p = if let Some(kp) = self.kp {
+            // Calculate the proportional term and limit to it's individual limit
+            let p_unbounded = kp.checked_mul(&error)
+                .ok_or(PidError::OpOverflow)?;
+            self.p_limit.clamp(p_unbounded)
+        } else {T::zero()};
+        
+        self.i_term = if let Some(ki) = self.ki {
+            let i_term = if let Some(i_term) = self.i_term {i_term}
+            else {T::zero()};
+            // Mitigate output jumps when ki(t) != ki(t-1).
+            // While it's standard to use an error_integral that's a running sum of
+            // just the error (no ki), because we support ki changing dynamically,
+            // we store the entire term so that we don't need to remember previous
+            // ki values.
+            let i_unbounded = ki.checked_mul(&error)
+                .ok_or(PidError::OpOverflow)?
+                .checked_add(&i_term)
+                .ok_or(PidError::OpOverflow)?;
+            // Mitigate integral windup: Don't want to keep building up error
+            // beyond what i_limit will allow.
+            Some(self.i_limit.clamp(i_unbounded))
+        } else {self.i_term};
 
-        // Calculate the proportional term and limit to it's individual limit
-        let p_unbounded = error * self.kp;
-        let p = p_unbounded.clamp(self.p_limit_low, self.p_limit_high);
+        let i = if let Some(i) = self.i_term {i}
+        else {T::zero()};
 
-        // Mitigate output jumps when ki(t) != ki(t-1).
-        // While it's standard to use an error_integral that's a running sum of
-        // just the error (no ki), because we support ki changing dynamically,
-        // we store the entire term so that we don't need to remember previous
-        // ki values.
-        let i_unbounded = self.i_term + error * self.ki;
+        let d = if let Some(kd) = self.kd {
+            // Mitigate derivative kick: Use the derivative of the measurement
+            // rather than the derivative of the error.
+            if let Some(prev_measurement) = self.prev_measurement {
+                let d_unbounded = measurement.checked_sub(&prev_measurement)
+                    .ok_or(PidError::OpOverflow)?
+                    .checked_mul(&kd)
+                    .ok_or(PidError::OpOverflow)?;
+                self.d_limit.clamp(d_unbounded)
+            } else {T::zero()}
+        } else {T::zero()};
 
-        // Mitigate integral windup: Don't want to keep building up error
-        // beyond what i_limit will allow.
-        self.i_term = i_unbounded.clamp(self.i_limit_low, self.i_limit_high);
+        let output = {
+            // Calculate the final output by adding together the PID terms, then
+            // apply the final defined output limit
+            let o_unbounded = p.checked_add(&i)
+                .ok_or(PidError::OpOverflow)?
+                .checked_add(&d)
+                .ok_or(PidError::OpOverflow)?;
+            self.out_limit.clamp(o_unbounded)
+        };
 
-        // Mitigate derivative kick: Use the derivative of the measurement
-        // rather than the derivative of the error.
-        let d_unbounded = -match self.prev_measurement.as_ref() {
-            Some(prev_measurement) => measurement - *prev_measurement,
-            None => T::default(),
-        } * self.kd;
         self.prev_measurement = Some(measurement);
-        let d = d_unbounded.clamp(self.d_limit_low, self.d_limit_high);
-
-        // Calculate the final output by adding together the PID terms, then
-        // apply the final defined output limit
-        let o_unbounded = p + self.i_term + d;
-        let output = o_unbounded.clamp(self.o_limit_low, self.o_limit_high);
 
         // Return the individual term's contributions and the final output
-        ControlOutput {
+        Ok(ControlOutput {
             p,
-            i: self.i_term,
+            i,
             d,
             output,
-        }
+        })
     }
 }
 
@@ -492,11 +395,11 @@ mod tests {
         assert_eq!(pid.setpoint, 10.0);
 
         // Test simple proportional
-        assert_eq!(pid.next_control_output(0.0).output, 20.0);
+        assert_eq!(pid.next_control_output(0.0).unwrap().output, 20.0);
 
         // Test proportional limit
         pid.p_limit = 10.0;
-        assert_eq!(pid.next_control_output(0.0).output, 10.0);
+        assert_eq!(pid.next_control_output(0.0).unwrap().output, 10.0);
     }
 
     /// Derivative-only controller operation and limits
@@ -508,14 +411,14 @@ mod tests {
             .d(2.0);
 
         // Test that there's no derivative since it's the first measurement
-        assert_eq!(pid.next_control_output(0.0).output, 0.0);
+        assert_eq!(pid.next_control_output(0.0).unwrap().output, 0.0);
 
         // Test that there's now a derivative
-        assert_eq!(pid.next_control_output(5.0).output, -10.0);
+        assert_eq!(pid.next_control_output(5.0).unwrap().output, -10.0);
 
         // Test derivative limit
         pid.d_limit = 5.0;
-        assert_eq!(pid.next_control_output(10.0).output, -5.0);
+        assert_eq!(pid.next_control_output(10.0).unwrap().output, -5.0);
     }
 
     /// Integral-only controller operation and limits
@@ -527,15 +430,15 @@ mod tests {
             .i(2.0);
 
         // Test basic integration
-        assert_eq!(pid.next_control_output(0.0).output, 20.0);
-        assert_eq!(pid.next_control_output(0.0).output, 40.0);
-        assert_eq!(pid.next_control_output(5.0).output, 50.0);
+        assert_eq!(pid.next_control_output(0.0).unwrap().output, 20.0);
+        assert_eq!(pid.next_control_output(0.0).unwrap().output, 40.0);
+        assert_eq!(pid.next_control_output(5.0).unwrap().output, 50.0);
 
         // Test limit
         pid.i_limit = 50.0;
-        assert_eq!(pid.next_control_output(5.0).output, 50.0);
+        assert_eq!(pid.next_control_output(5.0).unwrap().output, 50.0);
         // Test that limit doesn't impede reversal of error integral
-        assert_eq!(pid.next_control_output(15.0).output, 40.0);
+        assert_eq!(pid.next_control_output(15.0).unwrap().output, 40.0);
 
         // Test that error integral accumulates negative values
         let mut pid2 = Pid::new()
@@ -543,14 +446,14 @@ mod tests {
             .clamp(-100.0, 100.0)
             .i(2.0);
 
-        assert_eq!(pid2.next_control_output(0.0).output, -20.0);
-        assert_eq!(pid2.next_control_output(0.0).output, -40.0);
+        assert_eq!(pid2.next_control_output(0.0).unwrap().output, -20.0);
+        assert_eq!(pid2.next_control_output(0.0).unwrap().output, -40.0);
 
         pid2.i_limit_high = 50.0;
         pid2.i_limit_low = -50.0;
-        assert_eq!(pid2.next_control_output(-5.0).output, -50.0);
+        assert_eq!(pid2.next_control_output(-5.0).unwrap().output, -50.0);
         // Test that limit doesn't impede reversal of error integral
-        assert_eq!(pid2.next_control_output(-15.0).output, -40.0);
+        assert_eq!(pid2.next_control_output(-15.0).unwrap().output, -40.0);
     }
 
     /// Checks that a full PID controller's limits work properly through multiple output iterations
@@ -564,11 +467,11 @@ mod tests {
         pid.o_limit_high = 1.0;
         pid.o_limit_low = -1.0;
 
-        let out = pid.next_control_output(0.0);
+        let out = pid.next_control_output(0.0).unwrap();
         assert_eq!(out.p, 10.0); // 1.0 * 10.0
         assert_eq!(out.output, 1.0);
 
-        let out = pid.next_control_output(20.0);
+        let out = pid.next_control_output(20.0).unwrap();
         assert_eq!(out.p, -10.0); // 1.0 * (10.0 - 20.0)
         assert_eq!(out.output, -1.0);
     }
@@ -583,25 +486,25 @@ mod tests {
             .i(0.1)
             .d(1.0);
 
-        let out = pid.next_control_output(0.0);
+        let out = pid.next_control_output(0.0).unwrap();
         assert_eq!(out.p, 10.0); // 1.0 * 10.0
         assert_eq!(out.i, 1.0); // 0.1 * 10.0
         assert_eq!(out.d, 0.0); // -(1.0 * 0.0)
         assert_eq!(out.output, 11.0);
 
-        let out = pid.next_control_output(5.0);
+        let out = pid.next_control_output(5.0).unwrap();
         assert_eq!(out.p, 5.0); // 1.0 * 5.0
         assert_eq!(out.i, 1.5); // 0.1 * (10.0 + 5.0)
         assert_eq!(out.d, -5.0); // -(1.0 * 5.0)
         assert_eq!(out.output, 1.5);
 
-        let out = pid.next_control_output(11.0);
+        let out = pid.next_control_output(11.0).unwrap();
         assert_eq!(out.p, -1.0); // 1.0 * -1.0
         assert_eq!(out.i, 1.4); // 0.1 * (10.0 + 5.0 - 1)
         assert_eq!(out.d, -6.0); // -(1.0 * 6.0)
         assert_eq!(out.output, -5.6);
 
-        let out = pid.next_control_output(10.0);
+        let out = pid.next_control_output(10.0).unwrap();
         assert_eq!(out.p, 0.0); // 1.0 * 0.0
         assert_eq!(out.i, 1.4); // 0.1 * (10.0 + 5.0 - 1.0 + 0.0)
         assert_eq!(out.d, 1.0); // -(1.0 * -1.0)
@@ -622,8 +525,8 @@ mod tests {
 
         for _ in 0..5 {
             assert_eq!(
-                pid_f32.next_control_output(0.0).output,
-                pid_f64.next_control_output(0.0).output as f32
+                pid_f32.next_control_output(0.0).unwrap().output,
+                pid_f64.next_control_output(0.0).unwrap().output as f32
             );
         }
     }
@@ -642,8 +545,8 @@ mod tests {
 
         for _ in 0..5 {
             assert_eq!(
-                pid_i32.next_control_output(0).output,
-                pid_i8.next_control_output(0i8).output as i32
+                pid_i32.next_control_output(0).unwrap().output,
+                pid_i8.next_control_output(0i8).unwrap().output as i32
             );
         }
     }
@@ -658,7 +561,7 @@ mod tests {
             .i(0.1)
             .d(1.0);
 
-        let out = pid.next_control_output(0.0);
+        let out = pid.next_control_output(0.0).unwrap();
         assert_eq!(out.p, 10.0); // 1.0 * 10.0
         assert_eq!(out.i, 1.0); // 0.1 * 10.0
         assert_eq!(out.d, 0.0); // -(1.0 * 0.0)
@@ -667,7 +570,7 @@ mod tests {
         pid.setpoint(0.0);
 
         assert_eq!(
-            pid.next_control_output(0.0),
+            pid.next_control_output(0.0).unwrap(),
             ControlOutput {
                 p: 0.0,
                 i: 1.0,
@@ -690,7 +593,7 @@ mod tests {
         pid.o_limit_high = -10.0;
         pid.o_limit_low = 10.0;
 
-        let out = pid.next_control_output(0.0);
+        let out = pid.next_control_output(0.0).unwrap();
         assert_eq!(out.p, 10.0);
         assert_eq!(out.i, 10.0);
         assert_eq!(out.d, 0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ where
         // Set asymmetric limits
         self.out_limit.set(min, max);
         // Get maximum absolute value
-        let sym = if min.abs() > max.abs()) {min.abs()}
+        let sym = if min.abs() > max.abs() {min.abs()}
         else {max.abs()};
         // Set symmetric limits
         self.p_limit.set(-sym, sym);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,30 +191,6 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-impl <T: Number, F: Number> From<Pid<F>> for Pid<T>
-where
-    T: From<F>
-{
-    fn from(value: Pid<F>) -> Self {
-        Self {
-            setpoint: T::from(value.setpoint),
-            kp: T::from(value.kp),
-            ki: T::from(value.ki),
-            kd: T::from(value.kd),
-            p_limit_high: T::from(value.p_limit_high),
-            p_limit_low: T::from(value.p_limit_low),
-            i_limit_high: T::from(value.i_limit_high),
-            i_limit_low: T::from(value.i_limit_low),
-            d_limit_high: T::from(value.d_limit_high),
-            d_limit_low: T::from(value.d_limit_low),
-            o_limit_high: T::from(value.o_limit_high),
-            o_limit_low: T::from(value.o_limit_low),
-            i_term: T::from(value.i_term),
-            prev_measurement: value.prev_measurement.map(|v| T::from(v)),
-        }
-    }
-}
-
 impl Pid<i8>
 {
     pub const fn new_const() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl<T: PartialOrd + num_traits::Signed + Copy> Number for T {}
 /// # Type Warning
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
-#[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T> {
     /// Ideal setpoint to strive for.
@@ -151,7 +151,7 @@ pub struct Pid<T> {
 /// let output = pid.update(26.2456).unwrap();
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ControlOutput<T> {
     /// The input value to the controller.
@@ -170,7 +170,7 @@ pub struct ControlOutput<T> {
     pub output: T,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEqa)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PidLimit<T> {
     min: Option<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@
 //! use pid::Pid;
 //!
 //! // Create a new proportional-only PID controller with a setpoint of 15
-//! let mut pid = Pid::new(15.0, 100.0);
-//! pid.p(10.0, 100.0);
+//! let mut pid = Pid::new()
+//!     .setpoint(15.0)
+//!     .clamp(-100.0, 100.0)
+//!     .p(10.0);
 //!
 //! // Input a measurement with an error of 5.0 from our setpoint
 //! let output = pid.next_control_output(10.0);
@@ -24,7 +26,7 @@
 //! assert_eq!(output.p, 50.0);
 //!
 //! // Add a new integral term to the controller and input again
-//! pid.i(1.0, 100.0);
+//! pid.i(1.0);
 //! let output = pid.next_control_output(10.0);
 //!
 //! // Now that the integral makes the controller stateful, it will change
@@ -33,7 +35,7 @@
 //! assert_eq!(output.i, 5.0);
 //!
 //! // Add our final derivative term and match our setpoint target
-//! pid.d(2.0, 100.0);
+//! pid.d(2.0);
 //! let output = pid.next_control_output(15.0);
 //!
 //! // The output will now say to go down due to the derivative
@@ -44,26 +46,20 @@
 //! ```
 #![no_std]
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+trait PartialEqClamp {
+    fn clamp(self, min: Self, max: Self) -> Self;
+}
 
-/// A trait for any numeric type usable in the PID controller
-///
-/// This trait is automatically implemented for all types that satisfy `PartialOrd + num_traits::Signed + Copy`. This includes all of the signed float types and builtin integer except for [isize]:
-/// - [i8]
-/// - [i16]
-/// - [i32]
-/// - [i64]
-/// - [i128]
-/// - [f32]
-/// - [f64]
-///
-/// As well as any user type that matches the requirements
-pub trait Number: PartialOrd + num_traits::Signed + Copy {}
-
-// Implement `Number` for all types that
-// satisfy `PartialOrd + num_traits::Signed + Copy`.
-impl<T: PartialOrd + num_traits::Signed + Copy> Number for T {}
+impl<T> PartialEqClamp for T
+where
+    T: core::cmp::PartialOrd,
+{
+    fn clamp(self, min: Self, max: Self) -> Self {
+        if self.lt(min) {min} else 
+        if self.gt(max) {max} else 
+        {self}
+    }
+}
 
 /// Adjustable proportional-integral-derivative (PID) controller.
 ///
@@ -75,8 +71,10 @@ impl<T: PartialOrd + num_traits::Signed + Copy> Number for T {}
 /// use pid::Pid;
 ///
 /// // Create limited controller
-/// let mut p_controller = Pid::new(15.0, 100.0);
-/// p_controller.p(10.0, 100.0);
+/// let mut p_controller = Pid::new()
+///     .setpoint(15.0)
+///     .clamp(-100.0, 100.0)
+///     .p(10.0);
 ///
 /// // Get first output
 /// let p_output = p_controller.next_control_output(400.0);
@@ -88,8 +86,12 @@ impl<T: PartialOrd + num_traits::Signed + Copy> Number for T {}
 /// use pid::Pid;
 ///
 /// // Create full PID controller
-/// let mut full_controller = Pid::new(15.0, 100.0);
-/// full_controller.p(10.0, 100.0).i(4.5, 100.0).d(0.25, 100.0);
+/// let mut full_controller = Pid::new()
+///     .setpoint(15.0)
+///     .clamp(-100.0, 100.0);
+///     .p(10.0)
+///     .i(4.5)
+///     .d(0.25);
 ///
 /// // Get first output
 /// let full_output = full_controller.next_control_output(400.0);
@@ -103,12 +105,10 @@ impl<T: PartialOrd + num_traits::Signed + Copy> Number for T {}
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-pub struct Pid<T: Number> {
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct Pid<T> {
     /// Ideal setpoint to strive for.
     pub setpoint: T,
-    /// Defines the overall output filter limit.
-    pub output_limit: T,
     /// Proportional gain.
     pub kp: T,
     /// Integral gain.
@@ -116,15 +116,25 @@ pub struct Pid<T: Number> {
     /// Derivative gain.
     pub kd: T,
     /// Limiter for the proportional term: `-p_limit <= P <= p_limit`.
-    pub p_limit: T,
-    /// Limiter for the integral term: `-i_limit <= I <= i_limit`.
-    pub i_limit: T,
-    /// Limiter for the derivative term: `-d_limit <= D <= d_limit`.
-    pub d_limit: T,
+    pub p_limit_high: T,
+    /// Limiter for the derivative term: `p_limit_low <= P <= p_limit`.
+    pub p_limit_low: T,
+    /// Limiter for the integral term: `i_limit_low <= I <= i_limit_high`.
+    pub i_limit_high: T,
+    /// Limiter for the derivative term: `i_limit_low <= I <= i_limit_high`.
+    pub i_limit_low: T,
+    /// Limiter for the derivative term: `d_limit_low <= D <= d_limit_high`.
+    pub d_limit_high: T,
+    /// Limiter for the derivative term: `d_limit_low <= D <= d_limit_high`.
+    pub d_limit_low: T,
+    /// Limiter for the derivative term: `o_limit_low <= O <= o_limit_high`.
+    pub o_limit_high: T,
+    /// Limiter for the derivative term: `o_limit_low <= O <= o_limit_high`.
+    pub o_limit_low: T,
     /// Last calculated integral value if [Pid::ki] is used.
-    integral_term: T,
+    pub i_term: T,
     /// Previously found measurement whilst using the [Pid::next_control_output] method.
-    prev_measurement: Option<T>,
+    pub prev_measurement: Option<T>,
 }
 
 /// Output of [controller iterations](Pid::next_control_output) with weights
@@ -137,15 +147,19 @@ pub struct Pid<T: Number> {
 /// use pid::{Pid, ControlOutput};
 ///
 /// // Setup controller
-/// let mut pid = Pid::new(15.0, 100.0);
-/// pid.p(10.0, 100.0).i(1.0, 100.0).d(2.0, 100.0);
+/// let mut pid = Pid::new()
+///     .setpoint(15.0)
+///     .clamp(0.0, 100.0)
+///     .p(10.0)
+///     .i(1.0)
+///     .d(2.0);
 ///
 /// // Input an example value and get a report for an output iteration
 /// let output = pid.next_control_output(26.2456);
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
 #[derive(Debug, PartialEq, Eq)]
-pub struct ControlOutput<T: Number> {
+pub struct ControlOutput<T> {
     /// Contribution of the P term to the output.
     pub p: T,
     /// Contribution of the I term to the output.
@@ -160,47 +174,55 @@ pub struct ControlOutput<T: Number> {
 
 impl<T> Pid<T>
 where
-    T: Number,
+    T: core::ops::Sub<T, Output = T>
+        + core::ops::Add<T, Output = T>
+        + core::ops::Mul<T, Output = T>
+        + core::ops::Div<T, Output = T>
+        + core::cmp::PartialOrd
+        + Default
+        + core::ops::Neg<Output = T>
+        + core::marker::Copy,
 {
     /// Creates a new controller with the target setpoint and the output limit
     ///
-    /// To set your P, I, and D terms into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional term setting
-    /// - [Self::i()]: Integral term setting
-    /// - [Self::d()]: Derivative term setting
-    pub fn new(setpoint: impl Into<T>, output_limit: impl Into<T>) -> Self {
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub fn new() -> Self {
         Self {
-            setpoint: setpoint.into(),
-            output_limit: output_limit.into(),
-            kp: T::zero(),
-            ki: T::zero(),
-            kd: T::zero(),
-            p_limit: T::zero(),
-            i_limit: T::zero(),
-            d_limit: T::zero(),
-            integral_term: T::zero(),
+            setpoint: T::default(),
+            kp: T::default(),
+            ki: T::default(),
+            kd: T::default(),
+            p_limit_high: T::default(),
+            p_limit_low: T::default(),
+            i_limit_high: T::default(),
+            i_limit_low: T::default(),
+            d_limit_high: T::default(),
+            d_limit_low: T::default(),
+            o_limit_high: T::default(),
+            o_limit_low: T::default(),
+            integral_term: T::default(),
             prev_measurement: None,
         }
     }
 
-    /// Sets the [Self::p] term for this controller.
-    pub fn p(&mut self, gain: impl Into<T>, limit: impl Into<T>) -> &mut Self {
+    /// Sets the [Self::p] gain for this controller.
+    pub fn p(&mut self, gain: impl Into<T>) -> &mut Self {
         self.kp = gain.into();
-        self.p_limit = limit.into();
         self
     }
 
-    /// Sets the [Self::i] term for this controller.
-    pub fn i(&mut self, gain: impl Into<T>, limit: impl Into<T>) -> &mut Self {
+    /// Sets the [Self::i] gain for this controller.
+    pub fn i(&mut self, gain: impl Into<T>) -> &mut Self {
         self.ki = gain.into();
-        self.i_limit = limit.into();
         self
     }
 
-    /// Sets the [Self::d] term for this controller.
-    pub fn d(&mut self, gain: impl Into<T>, limit: impl Into<T>) -> &mut Self {
+    /// Sets the [Self::d] gain for this controller.
+    pub fn d(&mut self, gain: impl Into<T>) -> &mut Self {
         self.kd = gain.into();
-        self.d_limit = limit.into();
         self
     }
 
@@ -210,72 +232,82 @@ where
         self
     }
 
+    /// Sets the [Self::p] limit for this controller.
+    pub fn clamp(&mut self, low: impl Into<T>, high: impl Into<T>) -> &mut Self {
+        self.p_limit_low = low.into();
+        self.p_limit_high = high.into();
+        self.i_limit_low = low.into();
+        self.i_limit_high = high.into();
+        self.d_limit_low = low.into();
+        self.d_limit_high = high.into();
+        self.o_limit_low = low.into();
+        self.o_limit_high = high.into();
+        self
+    }
+
+    /// Set integral term to a custom value. This might be useful to restore the
+    /// pid controller to a previous state after an interruption or crash.
+    pub fn set_integral_term(&mut self, i_term: impl Into<T>) -> &mut Self {
+        let i_unbound: T = i_term.into();
+        self.i_term = i_unbound.clamp(self.i_limit_low, self.i_limit_high);
+        self
+    }
+
+    /// Resets the integral term back to zero, this may drastically change the
+    /// control output.
+    pub fn reset_integral_term(&mut self) -> &mut Self {
+        self.set_integral_term(T::default())
+    }
+
     /// Given a new measurement, calculates the next [control output](ControlOutput).
     ///
     /// # Panics
     ///
     /// - If a setpoint has not been set via `update_setpoint()`.
-    pub fn next_control_output(&mut self, measurement: T) -> ControlOutput<T> {
+    pub fn next_control_output(&mut self, measurement: impl Into<T>) -> ControlOutput<T> {
+        let measurement: T = measurement.into();
+        
         // Calculate the error between the ideal setpoint and the current
         // measurement to compare against
         let error = self.setpoint - measurement;
 
         // Calculate the proportional term and limit to it's individual limit
         let p_unbounded = error * self.kp;
-        let p = apply_limit(self.p_limit, p_unbounded);
+        let p = p_unbounded.clamp(self.p_limit_low, self.p_limit_high);
 
         // Mitigate output jumps when ki(t) != ki(t-1).
         // While it's standard to use an error_integral that's a running sum of
         // just the error (no ki), because we support ki changing dynamically,
         // we store the entire term so that we don't need to remember previous
         // ki values.
-        self.integral_term = self.integral_term + error * self.ki;
+        let i_unbounded = self.i_term + error * self.ki;
 
         // Mitigate integral windup: Don't want to keep building up error
         // beyond what i_limit will allow.
-        self.integral_term = apply_limit(self.i_limit, self.integral_term);
+        self.i_term = i_unbounded.clamp(self.i_limit_low, self.i_limit_high);
 
         // Mitigate derivative kick: Use the derivative of the measurement
         // rather than the derivative of the error.
         let d_unbounded = -match self.prev_measurement.as_ref() {
             Some(prev_measurement) => measurement - *prev_measurement,
-            None => T::zero(),
+            None => T::default(),
         } * self.kd;
         self.prev_measurement = Some(measurement);
-        let d = apply_limit(self.d_limit, d_unbounded);
+        let d = d_unbounded.clamp(self.d_limit_low, self.d_limit_high);
 
         // Calculate the final output by adding together the PID terms, then
         // apply the final defined output limit
-        let output = p + self.integral_term + d;
-        let output = apply_limit(self.output_limit, output);
+        let o_unbounded = p + self.i_term + d;
+        let output = o_unbounded.clamp(self.o_limit_low, self.o_limit_high);
 
         // Return the individual term's contributions and the final output
         ControlOutput {
             p,
-            i: self.integral_term,
+            i: self.i_term,
             d,
-            output: output,
+            output,
         }
     }
-
-    /// Resets the integral term back to zero, this may drastically change the
-    /// control output.
-    pub fn reset_integral_term(&mut self) {
-        self.integral_term = T::zero();
-    }
-
-    /// Set integral term to a custom value. This might be useful to restore the
-    /// pid controller to a previous state after an interruption or crash.
-    pub fn set_integral_term(&mut self, integral_term: impl Into<T>) -> &mut Self {
-        self.integral_term = integral_term.into();
-        self.integral_term = apply_limit(self.i_limit, self.integral_term);
-        self
-    }
-}
-
-/// Saturating the input `value` according the absolute `limit` (`-abs(limit) <= output <= abs(limit)`).
-fn apply_limit<T: Number>(limit: T, value: T) -> T {
-    num_traits::clamp(value, -limit.abs(), limit.abs())
 }
 
 #[cfg(test)]
@@ -286,8 +318,11 @@ mod tests {
     /// Proportional-only controller operation and limits
     #[test]
     fn proportional() {
-        let mut pid = Pid::new(10.0, 100.0);
-        pid.p(2.0, 100.0).i(0.0, 100.0).d(0.0, 100.0);
+        let mut pid = Pid::new()
+            .setpoint(10.0)
+            .clamp(-100.0, 100.0)
+            .p(2.0);
+        
         assert_eq!(pid.setpoint, 10.0);
 
         // Test simple proportional
@@ -301,8 +336,10 @@ mod tests {
     /// Derivative-only controller operation and limits
     #[test]
     fn derivative() {
-        let mut pid = Pid::new(10.0, 100.0);
-        pid.p(0.0, 100.0).i(0.0, 100.0).d(2.0, 100.0);
+        let mut pid = Pid::new()
+            .setpoint(10.0)
+            .clamp(-100.0, 100.0)
+            .d(2.0);
 
         // Test that there's no derivative since it's the first measurement
         assert_eq!(pid.next_control_output(0.0).output, 0.0);
@@ -318,8 +355,10 @@ mod tests {
     /// Integral-only controller operation and limits
     #[test]
     fn integral() {
-        let mut pid = Pid::new(10.0, 100.0);
-        pid.p(0.0, 100.0).i(2.0, 100.0).d(0.0, 100.0);
+        let mut pid = Pid::new()
+            .setpoint(10.0)
+            .clamp(-100.0, 100.0)
+            .i(2.0);
 
         // Test basic integration
         assert_eq!(pid.next_control_output(0.0).output, 20.0);
@@ -333,12 +372,16 @@ mod tests {
         assert_eq!(pid.next_control_output(15.0).output, 40.0);
 
         // Test that error integral accumulates negative values
-        let mut pid2 = Pid::new(-10.0, 100.0);
-        pid2.p(0.0, 100.0).i(2.0, 100.0).d(0.0, 100.0);
+        let mut pid2 = Pid::new()
+            .setpoint(-10.0)
+            .clamp(-100.0, 100.0)
+            .i(2.0);
+
         assert_eq!(pid2.next_control_output(0.0).output, -20.0);
         assert_eq!(pid2.next_control_output(0.0).output, -40.0);
 
-        pid2.i_limit = 50.0;
+        pid2.i_limit_high = 50.0;
+        pid2.i_limit_low = -50.0;
         assert_eq!(pid2.next_control_output(-5.0).output, -50.0);
         // Test that limit doesn't impede reversal of error integral
         assert_eq!(pid2.next_control_output(-15.0).output, -40.0);
@@ -347,8 +390,13 @@ mod tests {
     /// Checks that a full PID controller's limits work properly through multiple output iterations
     #[test]
     fn output_limit() {
-        let mut pid = Pid::new(10.0, 1.0);
-        pid.p(1.0, 100.0).i(0.0, 100.0).d(0.0, 100.0);
+        let mut pid = Pid::new()
+            .setpoint(10.0)
+            .clamp(-100.0, 100.0)
+            .p(1.0);
+
+        pid.o_limit_high = 1.0;
+        pid.o_limit_low = -1.0;
 
         let out = pid.next_control_output(0.0);
         assert_eq!(out.p, 10.0); // 1.0 * 10.0
@@ -362,8 +410,12 @@ mod tests {
     /// Combined PID operation
     #[test]
     fn pid() {
-        let mut pid = Pid::new(10.0, 100.0);
-        pid.p(1.0, 100.0).i(0.1, 100.0).d(1.0, 100.0);
+        let mut pid = Pid::new()
+            .setpoint(10.0)
+            .clamp(-100.0, 100.0)
+            .p(1.0)
+            .i(0.1)
+            .d(1.0);
 
         let out = pid.next_control_output(0.0);
         assert_eq!(out.p, 10.0); // 1.0 * 10.0
@@ -394,11 +446,13 @@ mod tests {
     /// PID operation with zero'd values, checking to see if different floats equal each other
     #[test]
     fn floats_zeros() {
-        let mut pid_f32 = Pid::new(10.0f32, 100.0);
-        pid_f32.p(0.0, 100.0).i(0.0, 100.0).d(0.0, 100.0);
+        let mut pid_f32 = Pid::new()
+            .setpoint(10.0f32)
+            .clamp(-100.0, 100.0);
 
-        let mut pid_f64 = Pid::new(10.0, 100.0f64);
-        pid_f64.p(0.0, 100.0).i(0.0, 100.0).d(0.0, 100.0);
+        let mut pid_f64 = Pid::new()
+            .setpoint(10.0)
+            .clamp(-100.0f64, 100.0f64);
 
         for _ in 0..5 {
             assert_eq!(
@@ -412,11 +466,13 @@ mod tests {
     /// PID operation with zero'd values, checking to see if different floats equal each other
     #[test]
     fn signed_integers_zeros() {
-        let mut pid_i8 = Pid::new(10i8, 100);
-        pid_i8.p(0, 100).i(0, 100).d(0, 100);
+        let mut pid_i8 = Pid::new()
+            .setpoint(10i8)
+            .clamp(-100, 100);
 
-        let mut pid_i32 = Pid::new(10i32, 100);
-        pid_i32.p(0, 100).i(0, 100).d(0, 100);
+        let mut pid_i32 = Pid::new()
+            .setpoint(10i32)
+            .clamp(-100, 100);
 
         for _ in 0..5 {
             assert_eq!(
@@ -429,8 +485,12 @@ mod tests {
     /// See if the controller can properly target to the setpoint after 2 output iterations
     #[test]
     fn setpoint() {
-        let mut pid = Pid::new(10.0, 100.0);
-        pid.p(1.0, 100.0).i(0.1, 100.0).d(1.0, 100.0);
+        let mut pid = Pid::new()
+            .setpoint(10.0)
+            .clamp(-100.0, 100.0)
+            .p(1.0)
+            .i(0.1)
+            .d(1.0);
 
         let out = pid.next_control_output(0.0);
         assert_eq!(out.p, 10.0); // 1.0 * 10.0
@@ -454,8 +514,15 @@ mod tests {
     /// Make sure negative limits don't break the controller
     #[test]
     fn negative_limits() {
-        let mut pid = Pid::new(10.0f32, -10.0);
-        pid.p(1.0, -50.0).i(1.0, -50.0).d(1.0, -50.0);
+        let mut pid = Pid::new()
+            .setpoint(10.0f32)
+            .clamp(50.0, -50.0)
+            .p(1.0)
+            .i(1.0)
+            .d(1.0);
+
+        pid.o_limit_high = -10.0;
+        pid.o_limit_low = 10.0;
 
         let out = pid.next_control_output(0.0);
         assert_eq!(out.p, 10.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub enum PidError {
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Pid<T: Number> {
+pub struct Pid<T> {
     /// Ideal setpoint to strive for.
     pub setpoint: Option<T>,
     /// Proportional gain.
@@ -161,7 +161,7 @@ pub struct Pid<T: Number> {
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct ControlOutput<T: Number> {
+pub struct ControlOutput<T> {
     /// Contribution of the P term to the output.
     pub p: T,
     /// Contribution of the I term to the output.
@@ -176,7 +176,7 @@ pub struct ControlOutput<T: Number> {
 
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct PidLimit<T: Number> {
+pub struct PidLimit<T> {
     min: Option<T>,
     max: Option<T>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,8 @@ where
     /// Resets the integral term back to zero, this may drastically change the
     /// control output.
     pub fn reset_integral_term(&mut self) -> &mut Self {
-        self.set_integral_term(T::zero())
+        self.i_term = None;
+        self
     }
 
     /// Given a new measurement, calculates the next [control output](ControlOutput).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@ use num_traits::CheckedMul;
 pub trait Number: num_traits::sign::Signed
     + PartialOrd
     + Copy
-    + CheckedBasic
 {}
 
 /// An error emitted due to problems with the PID controller.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,9 @@ where
         // Set asymmetric limits
         self.out_limit.set(min, max);
         // Get maximum absolute value
-        let sym = min.abs().max(max.abs());
+        let sym = if min.abs().ge(max.abs())
+        {min.abs()} else
+        {max.abs()};
         // Set symmetric limits
         self.p_limit.set(-sym, sym);
         self.i_limit.set(-sym, sym);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,30 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
+impl<T: Number, F: Number> From<Pid<F>> for Pid<T>
+where
+    T: From<F>
+{
+    fn from(value: Pid<F>) -> Self {
+        Self {
+            setpoint: T::from(value.setpoint),
+            kp: T::from(value.kp),
+            ki: T::from(value.ki),
+            kd: T::from(value.kd),
+            p_limit_high: T::from(value.p_limit_high),
+            p_limit_low: T::from(value.p_limit_low),
+            i_limit_high: T::from(value.i_limit_high),
+            i_limit_low: T::from(value.i_limit_low),
+            d_limit_high: T::from(value.d_limit_high),
+            d_limit_low: T::from(value.d_limit_low),
+            o_limit_high: T::from(value.o_limit_high),
+            o_limit_low: T::from(value.o_limit_low),
+            i_term: T::from(value.i_term),
+            prev_measurement: value.prev_measurement.map(|v| T::from(v)),
+        }
+    }
+}
+
 impl Pid<i8>
 {
     /// Creates a new controller
@@ -221,124 +245,34 @@ impl Pid<i8>
 
 impl Pid<i16>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
+        Self { ..Pid::<i8>::new() }
     }
 }
 
 impl Pid<i32>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
+        Self { ..Pid::<i8>::new() }
     }
 }
 
 impl Pid<i64>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
+        Self { ..Pid::<i8>::new() }
     }
 }
 
 impl Pid<i128>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
-        Self {
-            setpoint: 0,
-            kp: 0,
-            ki: 0,
-            kd: 0,
-            p_limit_high: 0,
-            p_limit_low: 0,
-            i_limit_high: 0,
-            i_limit_low: 0,
-            d_limit_high: 0,
-            d_limit_low: 0,
-            o_limit_high: 0,
-            o_limit_low: 0,
-            i_term: 0,
-            prev_measurement: None,
-        }
+        Self { ..Pid::<i8>::new() }
     }
 }
 
 impl Pid<f32>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
         Self {
             setpoint: 0.0,
@@ -361,29 +295,8 @@ impl Pid<f32>
 
 impl Pid<f64>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
-        Self {
-            setpoint: 0.0,
-            kp: 0.0,
-            ki: 0.0,
-            kd: 0.0,
-            p_limit_high: 0.0,
-            p_limit_low: 0.0,
-            i_limit_high: 0.0,
-            i_limit_low: 0.0,
-            d_limit_high: 0.0,
-            d_limit_low: 0.0,
-            o_limit_high: 0.0,
-            o_limit_low: 0.0,
-            i_term: 0.0,
-            prev_measurement: None,
-        }
+        Self { ..Pid::<f32>::new() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ where
 /// # Type Warning
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Send, Sync)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T> {
     /// Ideal setpoint to strive for.
@@ -158,7 +158,7 @@ pub struct Pid<T> {
 /// let output = pid.next_control_output(26.2456);
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Send, Sync)]
 pub struct ControlOutput<T> {
     /// Contribution of the P term to the output.
     pub p: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@
 /// - [f64]
 ///
 /// As well as any user type that matches the requirements
-pub trait Number: num_traits::sign::Signed + PartialOrd + Copy + Send {
-    pub fn clamp(self, min: Self, max: Self) -> Self;
+pub trait Number: num_traits::sign::Signed + PartialOrd + Default + Copy + Send {
+    fn clamp(self, min: Self, max: Self) -> Self;
 }
 
 // Implement `Number` for all types that
@@ -67,11 +67,12 @@ pub trait Number: num_traits::sign::Signed + PartialOrd + Copy + Send {
 impl<T> Number for T
 where
     T: num_traits::sign::Signed
-        + PartialOrd 
-        + Copy 
+        + PartialOrd
+        + Default
+        + Copy
         + Send,
 {
-    pub fn clamp(self, min: Self, max: Self) -> Self {
+    fn clamp(self, min: Self, max: Self) -> Self {
         if self < min {min} else 
         if self > max {max} else 
         {self}
@@ -203,19 +204,19 @@ where
     /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
         Self {
-            setpoint: 0 as T,
-            kp: 0 as T,
-            ki: 0 as T,
-            kd: 0 as T,
-            p_limit_high: 0 as T,
-            p_limit_low: 0 as T,
-            i_limit_high: 0 as T,
-            i_limit_low: 0 as T,
-            d_limit_high: 0 as T,
-            d_limit_low: 0 as T,
-            o_limit_high: 0 as T,
-            o_limit_low: 0 as T,
-            i_term: 0 as T,
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
             prev_measurement: None,
         }
     }
@@ -234,19 +235,19 @@ where
     /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
         Self {
-            setpoint: 0.0 as T,
-            kp: 0.0 as T,
-            ki: 0.0 as T,
-            kd: 0.0 as T,
-            p_limit_high: 0.0 as T,
-            p_limit_low: 0.0 as T,
-            i_limit_high: 0.0 as T,
-            i_limit_low: 0.0 as T,
-            d_limit_high: 0.0 as T,
-            d_limit_low: 0.0 as T,
-            o_limit_high: 0.0 as T,
-            o_limit_low: 0.0 as T,
-            i_term: 0.0 as T,
+            setpoint: 0.0,
+            kp: 0.0,
+            ki: 0.0,
+            kd: 0.0,
+            p_limit_high: 0.0,
+            p_limit_low: 0.0,
+            i_limit_high: 0.0,
+            i_limit_low: 0.0,
+            d_limit_high: 0.0,
+            d_limit_low: 0.0,
+            o_limit_high: 0.0,
+            o_limit_low: 0.0,
+            i_term: 0.0,
             prev_measurement: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-impl<T: Number, F: Number> From<Pid<F>> for Pid<T>
+impl const<T: Number, F: Number> From<Pid<F>> for Pid<T>
 where
     T: From<F>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,13 +76,11 @@ pub trait CheckedBasic: num_traits::ops::checked::CheckedAdd
 {}
 
 /// An error emitted due to problems with the PID controller.
-#[derive(Debug, Display)]
+#[derive(Debug)]
 pub enum PidError {
     NoSetpoint,
     OpOverflow,
 }
-
-impl core::error::Error for PidError {}
 
 /// Adjustable proportional-integral-derivative (PID) controller.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ use num_traits::CheckedMul;
 pub trait Number: num_traits::sign::Signed
     + PartialOrd
     + Copy
+    + CheckedBasic
 {}
 
 pub trait CheckedBasic: num_traits::ops::checked::CheckedAdd
@@ -72,11 +73,6 @@ pub trait CheckedBasic: num_traits::ops::checked::CheckedAdd
     + num_traits::ops::checked::CheckedMul
     + num_traits::ops::checked::CheckedDiv
     + num_traits::ops::checked::CheckedNeg
-{}
-
-impl<T> CheckedBasic for T
-where
-    T: Number
 {}
 
 /// An error emitted due to problems with the PID controller.
@@ -222,7 +218,7 @@ where
 
 impl<T> Pid<T>
 where
-    T: Number + CheckedBasic
+    T: Number
 {
     /// Creates a new controller
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ where
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Pid<T: num_traits::Num> {
+pub struct Pid<T> {
     /// Ideal setpoint to strive for.
     pub setpoint: T,
     /// Proportional gain.
@@ -160,7 +160,7 @@ pub struct Pid<T: num_traits::Num> {
 /// ```
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct ControlOutput<T: num_traits::Num> {
+pub struct ControlOutput<T> {
     /// Contribution of the P term to the output.
     pub p: T,
     /// Contribution of the I term to the output.
@@ -175,7 +175,7 @@ pub struct ControlOutput<T: num_traits::Num> {
 
 impl<T> Default for Pid<T>
 where
-    T: Default,
+    T: core::default::Default,
 {
     fn default() -> Self {
         Self::new()
@@ -184,7 +184,7 @@ where
 
 impl<T> Pid<T>
 where
-    T: num_traits::PrimInt,
+    T: num_traits::int::PrimInt,
 {
     /// Creates a new controller
     ///
@@ -214,7 +214,7 @@ where
 
 impl<T> Pid<T>
 where
-    T: num_traits::Num,
+    T: num_traits::float::FloatCore,
 {
     /// Creates a new controller
     ///
@@ -244,7 +244,8 @@ where
 
 impl<T> Pid<T>
 where
-    T: num_traits::Num,
+    T: num_traits::Num
+        + core::cmp::PartialOrd,
 {
     /// Sets the [Self::p] gain for this controller.
     pub fn p(&mut self, gain: impl Into<T>) -> &mut Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,8 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-unsafe impl<T> Send for Pid<T> where T: Send {}
-unsafe impl<T> Send for ControlOutput<T> where T: Send {}
+unsafe impl<T> Send for Pid<T> where T: Number {}
+unsafe impl<T> Send for ControlOutput<T> where T: Number {}
 
 impl Pid<i8>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ where
 /// # Type Warning
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Send)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T: Number> {
     /// Ideal setpoint to strive for.
@@ -176,7 +176,7 @@ pub struct Pid<T: Number> {
 /// let output = pid.next_control_output(26.2456);
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
-#[derive(Debug, PartialEq, Eq, Send)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ControlOutput<T: Number> {
     /// Contribution of the P term to the output.
@@ -190,6 +190,9 @@ pub struct ControlOutput<T: Number> {
     /// Output of the PID controller.
     pub output: T,
 }
+
+unsafe impl<T> Send for Pid<T> where T: Send {}
+unsafe impl<T> Send for ControlOutput<T> where T: Send {}
 
 impl Pid<i8>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,28 +246,28 @@ impl Pid<i8>
 impl Pid<i16>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new() }
+        Self { ..Pid::<i8>::new().into() }
     }
 }
 
 impl Pid<i32>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new() }
+        Self { ..Pid::<i8>::new().into() }
     }
 }
 
 impl Pid<i64>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new() }
+        Self { ..Pid::<i8>::new().into() }
     }
 }
 
 impl Pid<i128>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new() }
+        Self { ..Pid::<i8>::new().into() }
     }
 }
 
@@ -296,7 +296,7 @@ impl Pid<f32>
 impl Pid<f64>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<f32>::new() }
+        Self { ..Pid::<f32>::new().into() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,6 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-unsafe impl<T> Send for Pid<T> where T: Number {}
-unsafe impl<T> Send for ControlOutput<T> where T: Number {}
-
 impl Pid<i8>
 {
     /// Creates a new controller

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ where
     T: core::cmp::PartialOrd,
 {
     fn clamp(self, min: Self, max: Self) -> Self {
-        if self.lt(min) {min} else 
-        if self.gt(max) {max} else 
+        if self < min {min} else 
+        if self > max {max} else 
         {self}
     }
 }
@@ -203,7 +203,7 @@ where
             d_limit_low: T::default(),
             o_limit_high: T::default(),
             o_limit_low: T::default(),
-            integral_term: T::default(),
+            i_term: T::default(),
             prev_measurement: None,
         }
     }
@@ -234,14 +234,16 @@ where
 
     /// Sets the [Self::p] limit for this controller.
     pub fn clamp(&mut self, low: impl Into<T>, high: impl Into<T>) -> &mut Self {
-        self.p_limit_low = low.into();
-        self.p_limit_high = high.into();
-        self.i_limit_low = low.into();
-        self.i_limit_high = high.into();
-        self.d_limit_low = low.into();
-        self.d_limit_high = high.into();
-        self.o_limit_low = low.into();
-        self.o_limit_high = high.into();
+        let low = low.into();
+        let high = high.into();
+        self.p_limit_low = low;
+        self.p_limit_high = high;
+        self.i_limit_low = low;
+        self.i_limit_high = high;
+        self.d_limit_low = low;
+        self.d_limit_high = high;
+        self.o_limit_low = low;
+        self.o_limit_high = high;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ where
 /// # Type Warning
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Send, Sync)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T> {
     /// Ideal setpoint to strive for.
@@ -158,7 +158,7 @@ pub struct Pid<T> {
 /// let output = pid.next_control_output(26.2456);
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
-#[derive(Debug, PartialEq, Eq, Send, Sync)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ControlOutput<T> {
     /// Contribution of the P term to the output.
     pub p: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ impl<T> PidLimit<T>
 where
     T: Number
 {
+    /// Creates a new limit struct
     pub const fn new() -> Self {
         Self {
             min: None,
@@ -190,8 +191,17 @@ where
         }
     }
 
+    /// Sets the min and max limits
+    pub fn set(&mut self, min: impl Into<T>, max: impl Into<T>) -> &mut Self {
+        let min: T = min.into();
+        let max: T = max.into();
+        self.min = Some(min);
+        self.max = Some(max);
+        self
+    }
+
     /// Clamp a given value using pre-defined limits
-    pub fn clamp(self, value: impl Into<T>) -> T {
+    pub fn clamp(&self, value: impl Into<T>) -> T {
         let mut value: T = value.into();
         value = if let Some(min) = self.min {
             if value < min {min} else {value}
@@ -252,29 +262,11 @@ where
         self
     }
 
-    /// Sets the min and max limits for this controller.
-    pub fn clamp(&mut self, min: impl Into<T>, max: impl Into<T>) -> &mut Self {
-        self.clamp_min(min)
-            .clamp_max(max)
-    } 
-
-    /// Sets the min limits for this controller.
-    pub fn clamp_min(&mut self, min: impl Into<T>) -> &mut Self {
-        let min: T = min.into();
-        self.p_limit.min = Some(min);
-        self.i_limit.min = Some(min);
-        self.d_limit.min = Some(min);
-        self.out_limit.min = Some(min);
-        self
-    }
-
-    /// Sets the max limits for this controller.
-    pub fn clamp_max(&mut self, max: impl Into<T>) -> &mut Self {
-        let max: T = max.into();
-        self.p_limit.max = Some(max);
-        self.i_limit.max = Some(max);
-        self.d_limit.max = Some(max);
-        self.out_limit.max = Some(max);
+    /// Sets the min and max limits for the controller.
+    pub fn limit(&mut self, min: impl Into<T>, max: impl Into<T>) -> &mut Self {
+        self.p_limit.set(min, max);
+        self.i_limit.set(min, max);
+        self.out_limit.set(min, max);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,12 +392,12 @@ where
     /// 
     /// - If a setpoint has not been set via `setpoint()`.
     /// - If no gain is set via `p()`, `i()` or `d()`.
-    /// - If `dt` is zero.
+    /// - If `dt` <= zero.
     pub fn update_with_dt(&mut self, input: impl Into<T>, dt: impl Into<T>) -> Option<ControlOutput<T>> {
         // Convert parameters to number type
         let dt: T = dt.into();
         // Verify delta time value
-        if dt == T::zero() { return None };
+        if dt <= T::zero() { return None };
         // Store previous integral sum
         let i_term = self.i_term.map_or(T::zero(), |i| i);
         // Call normal update

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub trait CheckedBasic: num_traits::ops::checked::CheckedAdd
 {}
 
 /// An error emitted due to problems with the PID controller.
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum PidError {
     NoSetpoint,
     OpOverflow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub trait CheckedBasic: num_traits::ops::checked::CheckedAdd
 {}
 
 /// An error emitted due to problems with the PID controller.
-#[derive(Debug)]
+#[derive(Debug, core::error::Error)]
 pub enum PidError {
     NoSetpoint,
     OpOverflow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,9 +278,8 @@ where
         // Set asymmetric limits
         self.out_limit.set(min, max);
         // Get maximum absolute value
-        let sym = if min.abs().ge(max.abs())
-        {min.abs()} else
-        {max.abs()};
+        let sym = if min.abs() > max.abs()) {min.abs()}
+        else {max.abs()};
         // Set symmetric limits
         self.p_limit.set(-sym, sym);
         self.i_limit.set(-sym, sym);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
+#![feature(const_trait_impl)]
 impl const<T: Number, F: Number> From<Pid<F>> for Pid<T>
 where
     T: From<F>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,13 @@ pub trait CheckedBasic: num_traits::ops::checked::CheckedAdd
 {}
 
 /// An error emitted due to problems with the PID controller.
-#[derive(Debug, core::error::Error)]
+#[derive(Debug)]
 pub enum PidError {
     NoSetpoint,
     OpOverflow,
 }
+
+impl core::error::Error for PidError {}
 
 /// Adjustable proportional-integral-derivative (PID) controller.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,14 @@ where
     pub fn reset_integral_term(&mut self) {
         self.integral_term = T::zero();
     }
+
+    /// Set integral term to a custom value. This might be useful to restore the
+    /// pid controller to a previous state after an interruption or crash.
+    pub fn set_integral_term(&mut self, integral_term: impl Into<T>) -> &mut Self {
+        self.integral_term = integral_term.into();
+        self.integral_term = apply_limit(self.i_limit, self.integral_term);
+        self
+    }
 }
 
 /// Saturating the input `value` according the absolute `limit` (`-abs(limit) <= output <= abs(limit)`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,7 @@ pub struct ControlOutput<T: Number> {
     pub output: T,
 }
 
-#![feature(const_trait_impl)]
-impl const<T: Number, F: Number> From<Pid<F>> for Pid<T>
+impl <T: Number, F: Number> From<Pid<F>> for Pid<T>
 where
     T: From<F>
 {
@@ -218,12 +217,6 @@ where
 
 impl Pid<i8>
 {
-    /// Creates a new controller
-    ///
-    /// To set your P, I, and D gains into this controller, please use the following builder methods:
-    /// - [Self::p()]: Proportional gain setting
-    /// - [Self::i()]: Integral gain setting
-    /// - [Self::d()]: Derivative gain setting
     pub const fn new() -> Self {
         Self {
             setpoint: 0,
@@ -247,28 +240,88 @@ impl Pid<i8>
 impl Pid<i16>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new().into() }
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
     }
 }
 
 impl Pid<i32>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new().into() }
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
     }
 }
 
 impl Pid<i64>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new().into() }
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
     }
 }
 
 impl Pid<i128>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<i8>::new().into() }
+        Self {
+            setpoint: 0,
+            kp: 0,
+            ki: 0,
+            kd: 0,
+            p_limit_high: 0,
+            p_limit_low: 0,
+            i_limit_high: 0,
+            i_limit_low: 0,
+            d_limit_high: 0,
+            d_limit_low: 0,
+            o_limit_high: 0,
+            o_limit_low: 0,
+            i_term: 0,
+            prev_measurement: None,
+        }
     }
 }
 
@@ -297,12 +350,52 @@ impl Pid<f32>
 impl Pid<f64>
 {
     pub const fn new() -> Self {
-        Self { ..Pid::<f32>::new().into() }
+        Self {
+            setpoint: 0.0,
+            kp: 0.0,
+            ki: 0.0,
+            kd: 0.0,
+            p_limit_high: 0.0,
+            p_limit_low: 0.0,
+            i_limit_high: 0.0,
+            i_limit_low: 0.0,
+            d_limit_high: 0.0,
+            d_limit_low: 0.0,
+            o_limit_high: 0.0,
+            o_limit_low: 0.0,
+            i_term: 0.0,
+            prev_measurement: None,
+        }
     }
 }
 
 impl<T: Number> Pid<T>
 {
+    /// Creates a new controller
+    ///
+    /// To set your P, I, and D gains into this controller, please use the following builder methods:
+    /// - [Self::p()]: Proportional gain setting
+    /// - [Self::i()]: Integral gain setting
+    /// - [Self::d()]: Derivative gain setting
+    pub fn new() -> Self {
+        Self {
+            setpoint: T::default(),
+            kp: T::default(),
+            ki: T::default(),
+            kd: T::default(),
+            p_limit_high: T::default(),
+            p_limit_low: T::default(),
+            i_limit_high: T::default(),
+            i_limit_low: T::default(),
+            d_limit_high: T::default(),
+            d_limit_low: T::default(),
+            o_limit_high: T::default(),
+            o_limit_low: T::default(),
+            i_term: T::default(),
+            prev_measurement: None,
+        }
+    }
+
     /// Sets the [Self::p] gain for this controller.
     pub fn p(&mut self, gain: impl Into<T>) -> &mut Self {
         self.kp = gain.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,30 @@ pub struct ControlOutput<T> {
     pub output: T,
 }
 
+impl<T> Default for Pid<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            setpoint: T::default(),
+            kp: T::default(),
+            ki: T::default(),
+            kd: T::default(),
+            p_limit_high: T::default(),
+            p_limit_low: T::default(),
+            i_limit_high: T::default(),
+            i_limit_low: T::default(),
+            d_limit_high: T::default(),
+            d_limit_low: T::default(),
+            o_limit_high: T::default(),
+            o_limit_low: T::default(),
+            i_term: T::default(),
+            prev_measurement: None,
+        }
+    }
+}
+
 impl<T> Pid<T>
 where
     T: core::ops::Sub<T, Output = T>
@@ -190,22 +214,7 @@ where
     /// - [Self::i()]: Integral gain setting
     /// - [Self::d()]: Derivative gain setting
     pub fn new() -> Self {
-        Self {
-            setpoint: T::default(),
-            kp: T::default(),
-            ki: T::default(),
-            kd: T::default(),
-            p_limit_high: T::default(),
-            p_limit_low: T::default(),
-            i_limit_high: T::default(),
-            i_limit_low: T::default(),
-            d_limit_high: T::default(),
-            d_limit_low: T::default(),
-            o_limit_high: T::default(),
-            o_limit_low: T::default(),
-            i_term: T::default(),
-            prev_measurement: None,
-        }
+        Self::default()
     }
 
     /// Sets the [Self::p] gain for this controller.
@@ -234,8 +243,8 @@ where
 
     /// Sets the [Self::p] limit for this controller.
     pub fn clamp(&mut self, low: impl Into<T>, high: impl Into<T>) -> &mut Self {
-        let low = low.into();
-        let high = high.into();
+        let low: T = low.into();
+        let high: T = high.into();
         self.p_limit_low = low;
         self.p_limit_high = high;
         self.i_limit_low = low;


### PR DESCRIPTION
There is a very similar PR open already here #22, in fact I just copied one of the changes made in there and updated it further.

I opened this PR because the original did not get merged due to other changes unrelated to this one.

The feature is quite simple, the possibility of setting the integral sum term manually. This is necessary for restoring the state of the controller after a shutdown, as discussed in the original PR #22.

I am working on a project that requires PID control and this crate is just perfect for my use case, so I forked it myself to include the changes and i'm using this fork as a dependency. If you think you can merge this into master please let me know.