### PR TITLE
Fix clippy warning: redundant field names in struct initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ where
             p,
             i: self.integral_term,
             d,
-            output: output,
+            output,
         }
     }
 


### PR DESCRIPTION
Clippy made the following suggestion:

```
warning: redundant field names in struct initialization
   --> src/lib.rs:257:13
    |
257 |             output: output,
    |             ^^^^^^^^^^^^^^ help: replace it with: `output`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
    = note: `#[warn(clippy::redundant_field_names)]` on by default
```