### PR TITLE
Add a method to fully reset PID state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,11 @@ where
         }
     }
 
+    pub fn reset(&mut self) {
+        self.reset_integral_term();
+        self.prev_measurement = None;
+    }
+
     /// Resets the integral term back to zero, this may drastically change the
     /// control output.
     pub fn reset_integral_term(&mut self) {


### PR DESCRIPTION
When using this in my project there's sometimes a need to reset a PID, currently the only option to do that is to create a new one, this commit adds a utility method to just reset all the stateful parts without creation of new PID.