### PR TITLE
Add optional support for defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,15 @@ keywords = ["pid"]
 categories = ["no-std", "embedded", "algorithms"]
 readme = "README.md"
 
+[features]
+defmt = ["dep:defmt"]
+serde = ["dep:serde"]
+
+[dependencies.defmt]
+version = "1.0.1"
+optional = true
+default-features = false
+
 [dependencies.num-traits]
 version = "0.2"
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,6 @@
 //! ```
 #![no_std]
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 /// A trait for any numeric type usable in the PID controller
 ///
 /// This trait is automatically implemented for all types that satisfy `PartialOrd + num_traits::Signed + Copy`. This includes all of the signed float types and builtin integer except for [isize]:
@@ -102,8 +99,9 @@ impl<T: PartialOrd + num_traits::Signed + Copy> Number for T {}
 /// # Type Warning
 ///
 /// [Number] is abstract and can be used with anything from a [i32] to an [i128] (as well as user-defined types). Because of this, very small types might overflow during calculation in [`next_control_output`](Self::next_control_output). You probably don't want to use [i8] or user-defined types around that size so keep that in mind when designing your controller.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pid<T: Number> {
     /// Ideal setpoint to strive for.
     pub setpoint: T,
@@ -144,7 +142,9 @@ pub struct Pid<T: Number> {
 /// let output = pid.next_control_output(26.2456);
 /// println!("P: {}\nI: {}\nD: {}\nFinal Output: {}", output.p, output.i, output.d, output.output);
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ControlOutput<T: Number> {
     /// Contribution of the P term to the output.
     pub p: T,


### PR DESCRIPTION
This PR adds optional support for `defmt`. Very useful for embedded usage.

Also derives more standard traits for the structs.